### PR TITLE
Fixed Recurring events

### DIFF
--- a/RLBotDiscordBot/calendars.py
+++ b/RLBotDiscordBot/calendars.py
@@ -30,7 +30,7 @@ async def checkCalendar(message):
             name, some_time, time_until = date_time_check(today, jsons, 0)
             tournaments_embed = discord.Embed(
                         title=name,
-                        description=f"Will begin in {time_until}. ({some_time})" ,
+                        description=f"Will begin in {time_until}. ({some_time})" , #after even has started but not finished, this will say "Will being in {time} ago" I am not sure how to fix this using the API arguments
                         color=discord.Color.green()
                         )
             tournaments_embed.set_author(name="Upcoming Tournaments", icon_url="https://cdn.discordapp.com/avatars/474703464199356447/720a25621983c452cf71422a51b733a1.png?size=128")
@@ -56,6 +56,22 @@ def date_time_check(today, jsons, num):
     names = jsons["items"][num]["summary"]
     start = jsons["items"][num]["start"]["dateTime"]
     new_date = datetime.datetime.strptime(start, FORMAT)
+    try:
+        recurrence = jsons["items"][num]["recurrence"][0].split(";")
+        rec_type = recurrence[0].split("=")[1]
+        num_recs = recurrence[2].split("=")[1]
+        if rec_type == "WEEKLY":
+            for i in range(int(num_recs)):
+                if new_date > today:
+                    break
+                new_date += datetime.timedelta(days=7)
+        elif rec_type == "MONTHLY":
+            for i in range(int(num_recs)):
+                if new_date > today:
+                    break
+                new_date += datetime.timedelta(months=1)
+    except:
+        pass
     some_times = new_date.strftime(FORMAT2)
     time_untils = date.duration(new_date, now=today, precision=3)
     return names, some_times, time_untils

--- a/RLBotDiscordBot/calendars.py
+++ b/RLBotDiscordBot/calendars.py
@@ -36,16 +36,17 @@ async def checkCalendar(message):
             tournaments_embed.set_author(name="Upcoming Tournaments", icon_url="https://cdn.discordapp.com/avatars/474703464199356447/720a25621983c452cf71422a51b733a1.png?size=128")
             if len(jsons["items"]) >= 2:
                 name, some_time, time_until = date_time_check(today, jsons, 1)
-                tournaments_embed.add_field(name=name, value=f"Will begin in {time_until}. ({month_day}, {some_time})", inline=False)
+                tournaments_embed.add_field(name=name, value=f"Will begin in {time_until}. ({some_time})", inline=False)
             if len(jsons["items"]) == 3:
                 name, some_time, time_until = date_time_check(today, jsons, 2)
-                tournaments_embed.add_field(name=name, value=f"Will begin in {time_until}. ({month_day}, {some_time})", inline=False)
+                tournaments_embed.add_field(name=name, value=f"Will begin in {time_until}. ({some_time})", inline=False)
         else:
             tournaments_embed = discord.Embed(
                         description=f"No tournaments currently scheduled, if any are, they will appear here!" ,
                         color=discord.Color.red()
                         )
             tournaments_embed.set_author(name="Upcoming Tournaments", icon_url="https://cdn.discordapp.com/avatars/474703464199356447/720a25621983c452cf71422a51b733a1.png?size=128")
+        tournaments_embed.set_footer(text="http://rlbot.org/tournament/")
         await message.channel.send(" ", embed=tournaments_embed)
 
 


### PR DESCRIPTION
The way google's calendar API sends data broke it when a recurring event is added, this should be able to hand recurring events such as east's league play pretty well