### PR TITLE
Fixes for tournament embedd.

### DIFF
--- a/RLBotDiscordBot/calendars.py
+++ b/RLBotDiscordBot/calendars.py
@@ -15,10 +15,10 @@ import discord
 from discord.ext import commands
 from discord.utils import get
 
+FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+FORMAT2 = "%B %d, %H:%M UTC"
 
 async def checkCalendar(message):
-    FORMAT = "%Y-%m-%dT%H:%M:%SZ"
-    FORMAT2 = "%B %d, %H:%M UTC"
     today = datetime.datetime.utcnow()
     to_check = today.strftime(FORMAT)
     api_key = GOOGLE_API_KEY
@@ -26,38 +26,40 @@ async def checkCalendar(message):
     if "!tournaments" in args:
         r = requests.get(f"https://www.googleapis.com/calendar/v3/calendars/rlbotofficial@gmail.com/events?maxResults=3&timeMin={to_check}&key={api_key}")
         jsons = r.json()
-        if len(jsons["items"]) > 0:
-            name, some_time, time_until = date_time_check(today, jsons, 0)
-            tournaments_embed = discord.Embed(
-                        title=name,
-                        description=f"Will begin in {time_until}. ({some_time})" , #after even has started but not finished, this will say "Will being in {time} ago" I am not sure how to fix this using the API arguments
-                        color=discord.Color.green()
-                        )
-            tournaments_embed.set_author(name="Upcoming Tournaments", icon_url="https://cdn.discordapp.com/avatars/474703464199356447/720a25621983c452cf71422a51b733a1.png?size=128")
-            if len(jsons["items"]) >= 2:
-                name, some_time, time_until = date_time_check(today, jsons, 1)
-                tournaments_embed.add_field(name=name, value=f"Will begin in {time_until}. ({some_time})", inline=False)
-            if len(jsons["items"]) == 3:
-                name, some_time, time_until = date_time_check(today, jsons, 2)
-                tournaments_embed.add_field(name=name, value=f"Will begin in {time_until}. ({some_time})", inline=False)
+        if len(jsons["items"]) != 0:
+            tournaments_embed = discord.Embed(color=discord.Color.green())
+            events = []
+            for raw_event in jsons["items"]:
+                name, some_time, time_until = date_time_check(today, raw_event)
+                verb_tense = "Will Begin in" if "now" in time_until else "Began"
+                events.append({"name": name,
+                               "some_time": some_time,
+                               "time_until": time_until,
+                               "verb_tense": verb_tense})
+            events.sort(key=lambda ev: ev["time_until"])
+            for event in events:
+                tournaments_embed.add_field(name=event["name"],
+                                            value=f'{event["verb_tense"]} {event["time_until"]}. ({event["some_time"]})',
+                                            inline=False)
         else:
             tournaments_embed = discord.Embed(
-                        description=f"No tournaments currently scheduled, if any are, they will appear here!" ,
-                        color=discord.Color.red()
-                        )
-            tournaments_embed.set_author(name="Upcoming Tournaments", icon_url="https://cdn.discordapp.com/avatars/474703464199356447/720a25621983c452cf71422a51b733a1.png?size=128")
+                description=f"No tournaments currently scheduled, if any are, they will appear here!",
+                color=discord.Color.red())
+
+        tournaments_embed.set_author(name="Upcoming Tournaments",
+                                     icon_url="https://cdn.discordapp.com/avatars/474703464199356447/720a25621983c452cf71422a51b733a1.png?size=128",
+                                     url="http://rlbot.org/tournament/")
         tournaments_embed.set_footer(text="http://rlbot.org/tournament/")
+        tournaments_embed.url = "http://rlbot.org/tournament/"
         await message.channel.send(" ", embed=tournaments_embed)
 
 
-def date_time_check(today, jsons, num):
-    FORMAT = "%Y-%m-%dT%H:%M:%SZ"
-    FORMAT2 = "%B %d, %H:%M UTC"
-    names = jsons["items"][num]["summary"]
-    start = jsons["items"][num]["start"]["dateTime"]
+def date_time_check(today, event):
+    names = event["summary"]
+    start = event["start"]["dateTime"]
     new_date = datetime.datetime.strptime(start, FORMAT)
     try:
-        recurrence = jsons["items"][num]["recurrence"][0].split(";")
+        recurrence = event["recurrence"][0].split(";")
         rec_type = recurrence[0].split("=")[1]
         num_recs = recurrence[2].split("=")[1]
         if rec_type == "WEEKLY":
@@ -69,7 +71,7 @@ def date_time_check(today, jsons, num):
             for i in range(int(num_recs)):
                 if new_date > today:
                     break
-                new_date += datetime.timedelta(months=1)
+                new_date += datetime.timedelta(weeks=4)
     except:
         pass
     some_times = new_date.strftime(FORMAT2)


### PR DESCRIPTION
Fixed recurrent events ordering issue
Fixed verb tense issue: "Will begin x minutes ago"
![image](https://user-images.githubusercontent.com/19365140/107859570-3f0a6c80-6e32-11eb-801b-5187406943d8.png)
Added url to embedded title
Fixed issue with datetime.timedelta(months=1). months is not a acceptable argument, replaced with 4 weeks.

