### PR TITLE
Prefer longer commands

### DIFF
--- a/RLBotDiscordBot/settings_example.json
+++ b/RLBotDiscordBot/settings_example.json
@@ -7,6 +7,5 @@
     "Status_message": "with bots!",
     "Whitelisted_clip_domains": [
         "clips.twitch.tv"
-    ],
-    "Language_roles": ["Python"]
+    ]
 }


### PR DESCRIPTION
This changes how commands are parsed. It will now prefer longer commands, which allows commands to be prefixes of other commands. E.g. assume we have two commands !league and !leagueranks, the message "!leagueranks" should trigger !leagueranks and not !league